### PR TITLE
Always return a new array.

### DIFF
--- a/stable.js
+++ b/stable.js
@@ -13,11 +13,17 @@ var stable = function(arr, comp) {
         };
     }
 
+    var len = arr.length;
+
+    // Ensure we always return a new array, even if no passes occur.
+    if (len === 1) {
+        return arr.slice();
+    }
+
     // Rather than dividing input, simply iterate chunks of 1, 2, 4, 8, etc.
     // Chunks are the size of the left or right hand in merge sort.
     // Stop when the left-hand covers all of the array.
-    var len = arr.length, chk;
-    for (chk = 1; chk < len; chk *= 2) {
+    for (var chk = 1; chk < len; chk *= 2) {
         arr = pass(arr, comp, chk);
     }
     return arr;

--- a/test.js
+++ b/test.js
@@ -16,6 +16,14 @@ function objCmp(a, b) {
     return a.x > b.x;
 }
 
+test('always returns a new array', function (t) {
+    var array = [1];
+
+    t.doesNotEqual(array, stable(array));
+
+    t.end();
+});
+
 
 test('basic sorting', function(t) {
     t.same(


### PR DESCRIPTION
This fixed a very nasty bug in my program that was relying on the always-new behavior.
