### PR TITLE
type declarations: allow ReadonlyArray as parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export = stable;
 
 type Comparator<T> = ((a : T, b : T)=>boolean) | ((a: T, b : T)=>number);
 
-declare function stable<T>(array : T[], comparator? : Comparator<T>) : T[];
+declare function stable<T>(array : ReadonlyArray<T>, comparator? : Comparator<T>) : T[];
 declare namespace stable {
     export function inplace<T>(array: T[], comparator? : Comparator<T>) : T[];
 }


### PR DESCRIPTION
The input array to `stable` is not modified. It can therefore be a `ReadonlyArray`